### PR TITLE
Refresh positions on upload

### DIFF
--- a/app.ipynb
+++ b/app.ipynb
@@ -11,7 +11,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "04cde1805e524ba4a547841625d47bd7",
+       "model_id": "7c63b65b3c754e069b568feeef589d80",
        "version_major": 2,
        "version_minor": 0
       },

--- a/pyspreads/gui/gui.py
+++ b/pyspreads/gui/gui.py
@@ -39,6 +39,7 @@ class VerticalGUI(MarketGUI, PositionsGUI):
         self.tabs.set_title(4, 'About')
 
         self.observe(self.update_trade, names=['market', 'asset'])
+        self.observe(self.reset_positions, names=['market', 'asset'])
         self.update_all()
 
     def _build_trade_children(self):

--- a/pyspreads/gui/gui.py
+++ b/pyspreads/gui/gui.py
@@ -132,7 +132,6 @@ class VerticalGUI(MarketGUI, PositionsGUI):
     def update_trade(self, change=None):
         self.trade_widget.children = self._build_trade_children()
 
-
     def update_all(self):
         self.update_market()
         self.update_positions()

--- a/pyspreads/gui/positions.py
+++ b/pyspreads/gui/positions.py
@@ -35,6 +35,10 @@ class PositionsGUI(VerticalModel, GUIBase):
         self._update_positions_summary()
         self.draw_positions_plot()
 
+    def reset_positions(self, change=None):
+        self.clear_positions()
+        self.update_positions(change=change)
+
     @property
     def positions_screen(self):
         return widgets.HBox([self.positions_output, self.positions_summary])


### PR DESCRIPTION
Clear positions and draw a new (blank) positions graph when the data/asset price is updated.

Closes #1 